### PR TITLE
Add debug-only reset for testing

### DIFF
--- a/Afflo/Views/ExploreView.swift
+++ b/Afflo/Views/ExploreView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct ExploreView: View {
     @Environment(\.colorScheme) var colorScheme
+    @StateObject private var authViewModel = AuthViewModel()
 
     var body: some View {
         ZStack {
@@ -14,6 +15,24 @@ struct ExploreView: View {
                 Text("Explore")
                     .font(.anonymousPro(size: 24))
                     .foregroundColor(Color.text(for: colorScheme))
+
+                Spacer()
+
+                #if DEBUG
+                Button(action: {
+                    Task {
+                        await authViewModel.signOut()
+                    }
+                }) {
+                    Text("Reset App (Debug Only)")
+                        .font(.anonymousPro(size: 14))
+                        .foregroundColor(.red)
+                        .padding()
+                        .background(Color.red.opacity(0.1))
+                        .cornerRadius(8)
+                }
+                .padding(.bottom, 40)
+                #endif
             }
         }
     }

--- a/Afflo/Views/HomeView.swift
+++ b/Afflo/Views/HomeView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct HomeView: View {
     @Environment(\.colorScheme) var colorScheme
+    @StateObject private var authViewModel = AuthViewModel()
 
     var body: some View {
         ZStack {
@@ -14,6 +15,24 @@ struct HomeView: View {
                 Text("Home")
                     .font(.anonymousPro(size: 24))
                     .foregroundColor(Color.text(for: colorScheme))
+
+                Spacer()
+
+                #if DEBUG
+                Button(action: {
+                    Task {
+                        await authViewModel.signOut()
+                    }
+                }) {
+                    Text("Reset App (Debug Only)")
+                        .font(.anonymousPro(size: 14))
+                        .foregroundColor(.red)
+                        .padding()
+                        .background(Color.red.opacity(0.1))
+                        .cornerRadius(8)
+                }
+                .padding(.bottom, 40)
+                #endif
             }
         }
     }


### PR DESCRIPTION
Debug-only reset button in Home/Explore views. Allows testing full auth → onboarding → tabs flow repeatedly. Only visible in debug builds (#if DEBUG).